### PR TITLE
fix: mcp 도구 사용 방식 및 이메일 조회 로직을 수정한다

### DIFF
--- a/app/cc_checkers/atlassian/jira_checker.py
+++ b/app/cc_checkers/atlassian/jira_checker.py
@@ -90,7 +90,7 @@ JSON 배열로만 응답 (설명 없이):
 
     try:
         async with ClaudeSDKClient(options=options) as client:
-            await client.query("mcp__atlassian 도구를 사용해서 할당된 Jira 티켓을 조회하고 JSON으로 반환해주세요.")
+            await client.query("mcp__atlassian__* 도구를 사용해서 할당된 Jira 티켓을 조회하고 JSON으로 반환해주세요.")
 
             result_message = ""
             async for message in client.receive_response():

--- a/app/cc_checkers/ms365/outlook_agent.py
+++ b/app/cc_checkers/ms365/outlook_agent.py
@@ -123,7 +123,7 @@ async def call_email_task_extractor(
     settings = get_settings()
     bot_name = settings.BOT_NAME or "봇"
 
-    email_task_memory_query = f"""다음 {len(emails)}개의 이메일에서 관련된 모든 사람의 정보를 찾아 메모리를 취합해 알려주세요.
+    email_task_memory_query = f"""다음 {len(emails)}개의 이메일에서 발신자의 정보와 관련된 모든 사람의 정보를 찾아 메모리를 취합해 알려주세요.
 반드시 해당 채널과 요청 유저에 대한 **지침**과 정보(channel_id, user_id, user_name)를 포함하세요.
 
 {emails_text}"""

--- a/app/cc_checkers/ms365/outlook_checker.py
+++ b/app/cc_checkers/ms365/outlook_checker.py
@@ -45,10 +45,10 @@ async def fetch_new_emails() -> List[Dict[str, Any]]:
     }
 
     system_prompt = """당신은 Outlook 이메일 데이터 수집 전문가입니다.
-Lokka MCP (Microsoft 365 MCP)를 사용하여 이메일 목록을 조회하고, 구조화된 JSON 데이터로 반환해야 합니다.
+Lokka MCP (Microsoft 365 MCP)를 사용하여 읽지 않은 이메일 목록을 조회하고, 구조화된 JSON 데이터로 반환해야 합니다.
 
 **작업 지시:**
-1. `mcp__ms365__*` 도구를 사용하여 받은편지함의 읽지 않은 이메일을 최신 10개까지 조회하세요
+1. `mcp__ms365__*` 도구를 사용하여 받은편지함의 읽지 않은 이메일을 최신 순으로 최대 10개까지 조회하세요
 2. 조회한 이메일들을 **모두 읽음으로 표시**하세요
 3. 각 이메일에 대해 다음 정보를 추출하세요:
    - id: 이메일 ID
@@ -92,10 +92,7 @@ Lokka MCP (Microsoft 365 MCP)를 사용하여 이메일 목록을 조회하고, 
 ]
 ```
 
-**주의사항:**
-- 읽지 않은 이메일만 조회 (isRead=false 필터)
-- 최신순으로 정렬
-- 최대 10개까지만"""
+**주의:** 읽지 않은 이메일이 없으면 빈 배열 [] 반환"""
 
     try:
         options = ClaudeAgentOptions(
@@ -121,7 +118,7 @@ Lokka MCP (Microsoft 365 MCP)를 사용하여 이메일 목록을 조회하고, 
         )
 
         async with ClaudeSDKClient(options=options) as client:
-            await client.query("받은편지함의 읽지 않은 이메일을 최신 10개까지 조회해주세요.")
+            await client.query("mcp__ms365__* 도구를 사용해서 받은편지함의 읽지 않은 이메일을 최신 10개까지 조회하고 JSON으로 반환해주세요.")
 
             async for message in client.receive_response():
                 if isinstance(message, ResultMessage):


### PR DESCRIPTION
Jira 티켓 조회 시 mcp 도구 사용 방식을 명확히 한다

Outlook 이메일 조회 시 읽지 않은 이메일만 조회하도록 수정하고, 관련 안내 문구를 보완한다

이메일 작업 추출 시 발신자 정보를 포함하도록 수정한다