### PR TITLE
Adds "Open in Finder" button in Data Storage Folder

### DIFF
--- a/electron-app/locales/en.json
+++ b/electron-app/locales/en.json
@@ -61,7 +61,8 @@
     "role": "Role/Position",
     "roleHint": "Describe the bot's role and main responsibilities",
     "dataPath": "Data Storage Path",
-    "dataPathHint": "Location for files and data storage"
+    "dataPathHint": "Location for files and data storage",
+    "openInFinder": "Open in Finder"
   },
   "mcp": {
     "perplexity": "Perplexity",

--- a/electron-app/locales/ko.json
+++ b/electron-app/locales/ko.json
@@ -61,7 +61,8 @@
     "role": "직군/역할",
     "roleHint": "봇의 직군과 주요 역할을 설명하세요",
     "dataPath": "데이터 저장 경로",
-    "dataPathHint": "파일 및 데이터 저장 위치"
+    "dataPathHint": "파일 및 데이터 저장 위치",
+    "openInFinder": "Finder에서 열기"
   },
   "mcp": {
     "perplexity": "Perplexity",

--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -9,7 +9,7 @@
  * 5. Auto-updater functionality
  */
 
-const { app, BrowserWindow, ipcMain, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog, shell } = require('electron');
 const { autoUpdater } = require('electron-updater');
 const log = require('electron-log');
 const { spawn, execSync } = require('child_process');
@@ -776,6 +776,29 @@ function registerIPCHandlers() {
 
   ipcMain.handle('get-language', async () => {
     return currentLang;
+  });
+
+  ipcMain.handle('open-data-folder', async (_event, folderPath) => {
+    try {
+      // Expand home directory if path starts with ~
+      let expandedPath = folderPath;
+      if (folderPath.startsWith('~')) {
+        expandedPath = path.join(os.homedir(), folderPath.slice(1));
+      }
+
+      // Create directory if it doesn't exist
+      if (!fs.existsSync(expandedPath)) {
+        fs.mkdirSync(expandedPath, { recursive: true });
+      }
+
+      // Open the folder in Finder/Explorer
+      shell.openPath(expandedPath);
+
+      return { success: true };
+    } catch (error) {
+      log.error('Error opening data folder:', error);
+      return { error: error.message };
+    }
   });
 }
 

--- a/electron-app/preload.js
+++ b/electron-app/preload.js
@@ -44,6 +44,9 @@ contextBridge.exposeInMainWorld('api', {
   setLanguage: (lang) => ipcRenderer.invoke('set-language', lang),
   getLanguage: () => ipcRenderer.invoke('get-language'),
 
+  // File system
+  openDataFolder: (path) => ipcRenderer.invoke('open-data-folder', path),
+
   // Server logs
   onServerLog: (callback) => {
     ipcRenderer.on('server-log', (_event, data) => callback(data));

--- a/electron-app/renderer/index.html
+++ b/electron-app/renderer/index.html
@@ -173,7 +173,12 @@
 
             <div class="form-group">
               <label for="FILESYSTEM_BASE_DIR" data-i18n="bot.dataPath">데이터 저장 경로</label>
-              <input type="text" id="FILESYSTEM_BASE_DIR" placeholder="/Users/yourname/KIRA/data">
+              <div style="display: flex; gap: 10px; align-items: center;">
+                <input type="text" id="FILESYSTEM_BASE_DIR" placeholder="/Users/yourname/KIRA/data" style="flex: 1;">
+                <button type="button" class="btn btn-small btn-primary" id="open-data-folder">
+                  <span data-i18n="bot.openInFinder">Finder에서 열기</span>
+                </button>
+              </div>
               <small data-i18n="bot.dataPathHint">파일 및 데이터 저장 위치</small>
             </div>
           </section>

--- a/electron-app/renderer/main.js
+++ b/electron-app/renderer/main.js
@@ -314,6 +314,24 @@ function setupEventListeners() {
   document.getElementById('startServerBtn').addEventListener('click', startServer);
   document.getElementById('stopServerBtn').addEventListener('click', stopServer);
 
+  // Open data folder button
+  const openDataFolderBtn = document.getElementById('open-data-folder');
+  if (openDataFolderBtn) {
+    openDataFolderBtn.addEventListener('click', async () => {
+      const dataPath = document.getElementById('FILESYSTEM_BASE_DIR').value;
+      if (dataPath) {
+        const result = await window.api.openDataFolder(dataPath);
+        if (result.error) {
+          console.error('Error opening folder:', result.error);
+          // Could show user-friendly error message here
+        }
+      } else {
+        // Path is empty, maybe show a message to user
+        console.log('Please enter a data storage path first');
+      }
+    });
+  }
+
   // MCP checkbox toggles
   Object.keys(mcpMapping).forEach(checkboxId => {
     const checkbox = document.getElementById(checkboxId);


### PR DESCRIPTION
Allows users to easily open the data storage folder in their system's file explorer.

This change introduces a button that, when clicked, opens the directory specified in the data path input field, creating the directory if it doesn't already exist. This improves user experience by providing quick access to the data storage location.