### PR TITLE
docs(ko): fix KRIS bold rendering

### DIFF
--- a/vitepress-app/ko/index.md
+++ b/vitepress-app/ko/index.md
@@ -72,7 +72,7 @@ features:
 
 > **KIRA** = **K**RAFTON **I**NTELLIGENCE **R**OOKIE **A**GENT
 
-KIRA는 KRAFTON 사내에서 성공적으로 사용 중인 AI 에이전트 시스템 **KRIS (KRAFTON Intelligence System)**를 "가상 직원" 컨셉에 맞게 리패키징한 오픈소스 프로젝트입니다. 누구나 설치하고 바로 사용할 수 있는 데스크톱 앱으로 만들었습니다 — 서버 설정도, 클라우드도 필요 없이 설치만 하면 끝.
+KIRA는 KRAFTON 사내에서 성공적으로 사용 중인 AI 에이전트 시스템 <strong>KRIS (KRAFTON Intelligence System)</strong>를 "가상 직원" 컨셉에 맞게 리패키징한 오픈소스 프로젝트입니다. 누구나 설치하고 바로 사용할 수 있는 데스크톱 앱으로 만들었습니다 — 서버 설정도, 클라우드도 필요 없이 설치만 하면 끝.
 
 ### 🎬 데모
 


### PR DESCRIPTION
**Description**
- Problem: On vitepress-app/ko/index.md, the markdown **KRIS (KRAFTON Intelligence System)**를 was rendered with the literal ** instead of bold text.
- Root cause: VitePress (markdown-it / CommonMark) emphasis parsing can fail at the closing ** boundary when it is adjacent to punctuation (e.g., )) and immediately followed by a Korean particle (letters), so the emphasis delimiter isn’t recognized as “closing”.
- Fix: Replaced the markdown emphasis with HTML: <strong>KRIS (KRAFTON Intelligence System)</strong>를, which avoids delimiter-boundary parsing edge cases.
- Scope: Docs-only, single-line change; verified locally on the /ko/ page.

**Optional checklist**
- [x] Verified rendering locally with `npm run docs:dev` (on below)
<img width="1043" height="634" alt="Screenshot 2025-12-16 at 3 24 17 PM" src="https://github.com/user-attachments/assets/faa39ad8-bf94-44fa-b188-c07b69106411" />

