### PR TITLE
chore: add missing placeholders to dev.env.example

### DIFF
--- a/app/config/env/dev.env.example
+++ b/app/config/env/dev.env.example
@@ -26,7 +26,7 @@ DEEPL_API_KEY=your-deepl-api-key
 
 # MCP 설정 - GitHub
 GITHUB_ENABLED=False
-GITHUB_PERSONAL_ACCESS_TOKEN=
+GITHUB_PERSONAL_ACCESS_TOKEN=ghp_your-github-token-here
 
 # MCP 설정 - GitLab
 GITLAB_ENABLED=False
@@ -66,7 +66,7 @@ CLOVA_INVOKE_URL=https://clovaspeech-gw.ncloud.com/external/v1/your-url
 CLOVA_SECRET_KEY=your-secret-key
 
 # MCP 설정 - Custom Remote MCP
-REMOTE_MCP_SERVERS=
+REMOTE_MCP_SERVERS=[{"name": "example-server", "url": "http://localhost:8000/mcp"}]
 
 # Computer Use
 CHROME_ENABLED=False
@@ -75,12 +75,12 @@ CHROME_ALWAYS_PROFILE_SETUP=False
 # 웹 서버 / 음성 수신 채널
 WEB_INTERFACE_ENABLED=False
 WEB_INTERFACE_AUTH_PROVIDER=microsoft
-WEB_INTERFACE_URL=
+WEB_INTERFACE_URL=https://your-web-app-url.com
 WEB_SLACK_CLIENT_ID=your-slack-client-id
 WEB_SLACK_CLIENT_SECRET=your-slack-client-secret
-WEB_MS365_CLIENT_ID=
-WEB_MS365_CLIENT_SECRET=
-WEB_MS365_TENANT_ID=
+WEB_MS365_CLIENT_ID=your-web-ms365-client-id
+WEB_MS365_CLIENT_SECRET=your-web-ms365-client-secret
+WEB_MS365_TENANT_ID=your-web-ms365-tenant-id
 
 # 능동 수신 채널 - Outlook
 OUTLOOK_CHECK_ENABLED=False


### PR DESCRIPTION
Added example values to empty configuration keys in `dev.env.example`.