### PR TITLE
fix: Enables piping of Python process logs

### DIFF
--- a/electron-app/main.js
+++ b/electron-app/main.js
@@ -546,8 +546,8 @@ async function startServer() {
   }
 
   // Pipe logs
-  // pythonProcess.stdout.pipe(logStream);
-  // pythonProcess.stderr.pipe(logStream);
+  pythonProcess.stdout.pipe(logStream);
+  pythonProcess.stderr.pipe(logStream);
 
   // Send logs to renderer with parsed log level
   const parseLogLevel = (logLine) => {


### PR DESCRIPTION
Pipe the standard error of the Python process to the log stream to ensure all logs are captured and processed.